### PR TITLE
Added command to reset the device via the register

### DIFF
--- a/src/ADS131M0x.cpp
+++ b/src/ADS131M0x.cpp
@@ -629,6 +629,37 @@ int32_t ADS131M0x::readfastCh0(void)
   return val32Ch0;
 }
 
+/// @brief reset device from register, read CAP 8.5.1.10 Commands from official documentation  
+/// @param  
+/// @return True if the device responded with the RSP_RESET_OK message
+bool ADS131M0x::resetDevice(void){
+  uint8_t x = 0;
+  uint8_t x2 = 0;
+  uint16_t ris = 0;
+
+  digitalWrite(csPin, LOW);
+  #ifndef NO_CS_DELAY
+    delayMicroseconds(1);
+  #endif
+
+  x = spiPort->transfer(0x00);
+  x2 = spiPort->transfer(0x11);
+  spiPort->transfer(0x00);
+
+  ris =  ((x << 8) | x2);
+
+  digitalWrite(csPin, HIGH);
+  #ifndef NO_CS_DELAY
+    delayMicroseconds(1);
+  #endif
+
+  if(RSP_RESET_OK == ris){
+    return true;
+  }
+  return false;
+}
+
+
 /// @brief Read ADC port (all Ports)
 /// @param  
 /// @return 

--- a/src/ADS131M0x.h
+++ b/src/ADS131M0x.h
@@ -281,6 +281,7 @@ public:
   bool setChannelOffsetCalibration(uint8_t channel, int32_t offset);
   bool setChannelGainCalibration(uint8_t channel, uint32_t gain);
   bool setOsr(uint16_t osr);
+  bool resetDevice(void);
 
   uint16_t isResetOK(void);
   adcOutput readADC(void);


### PR DESCRIPTION
Following the instructions in CAP 8.5.1.10 of the official documentation.
I added the command to reset the device via register, then I check if the returned value matches the default value of the reset device.
I tested the command on the Nucleo 64 G0b1RE device